### PR TITLE
Specify RPC version as 2 to get expected return

### DIFF
--- a/apacman
+++ b/apacman
@@ -72,7 +72,7 @@ editor="vi"
 pager="less -R"
 [[ $PAGER ]] && pager="$PAGER"
 
-RPCURL="https://aur.archlinux.org/rpc.php?type"
+RPCURL="https://aur.archlinux.org/rpc/?v=2&type"
 PKGURL="https://aur.archlinux.org"
 WEBURL="https://www.archlinux.org"
 ABSURL="rsync.archlinux.org"


### PR DESCRIPTION
Due to changes of RPC, we get unexpected return like

```
{"version":1,"type":"info","resultcount":0,"results":[]}
```

via `https://aur.archlinux.org/rpc.php` without `v=foo` param.

To avoid it, I changed `/rpc.php`, the rpc endpoint to `/rpc/` and
added `v` param by modifying RPCURL.

With `v=2` query, We can get JSON from RPC same as before, so 
there are nothing to do any more for `apacman` to work correctly.

PS.
It is hard for me to make myself understood in English, so please ask me if you cannot understand what I say.