### PR TITLE
Improve curlyq output (e.g. for -Syu)

### DIFF
--- a/apacman
+++ b/apacman
@@ -203,10 +203,10 @@ runasroot() {
   fi
 }
 
-# debugging for curl ($1 is curl exit code)
+# debugging for curl ($1 is curl exit code, $2 package name)
 curlyq() {
   if [ $1 -ne 0 -a $1 -ne 7 ]; then
-    echo -e "${COLOR6}notice:${ENDCOLOR} curl exited with code $1"
+    echo -e "${COLOR6}notice:${ENDCOLOR} curl exited with code $1 on $2"
     if deptest man; then
       curlman=$(man curl | sed '1,/^EXIT CODES/d' | grep " $1 ")
       curlman=$(echo "$curlman" | awk -F "    " '{print $3}' | sed 's/^[ \t]*//')
@@ -526,10 +526,10 @@ pkginfo() {
     basepath=$(echo ${pkgpath##*/} | awk -F . '{print $1}')
     if [[ $legacy == 1 ]]; then
       curl -Lfs "${pkgpath%/*}/PKGBUILD" > "$tmpdir/$1.PKGBUILD"
-      cstatus=$?; curlyq "$cstatus"
+      cstatus=$?; curlyq "$cstatus" "$1"
     else
       curl -Lfs "${pkgpath%/*/*}/plain/PKGBUILD?h=${basepath}" > "$tmpdir/$1.PKGBUILD"
-      cstatus=$?; curlyq "$cstatus"
+      cstatus=$?; curlyq "$cstatus" "$1"
     fi
 
     if [[ $2 ]]; then
@@ -711,7 +711,7 @@ aurinstall() {
     mkdir -p "$builddir"
     cd "$builddir"
     curl -Lfs "$(pkglink $1)" > "$1.tar.gz"
-    cstatus=$?; curlyq "$cstatus"
+    cstatus=$?; curlyq "$cstatus" "$1"
     mkdir "$1"
     tar xf "$1.tar.gz" -C "$1" --strip-components=1
     cd "$1"
@@ -1279,7 +1279,7 @@ if [[ $option = download ]]; then
   [[ $pkglist ]] && echo -e "${COLOR6}notice:$ENDCOLOR sourcing from ${COLOR3}[AUR]$ENDCOLOR"
   for package in "${pkglist[@]}"; do
     curl -Lfs "$(pkglink $package)" > "$package.tar.gz"
-    cstatus=$?; curlyq "$cstatus"
+    cstatus=$?; curlyq "$cstatus" "$package"
     [ -d "$package" ] && rm -r "$package"
     if [ -f "$package.tar.gz" ]; then
       mkdir "$package"
@@ -1474,7 +1474,7 @@ if [[ $option = web ]]; then
       echo -e "${COLOR7}error:${ENDCOLOR} comments unavailable for non-AUR package '$package'"
     elif ! [[ $noaur ]]; then # Check to see if it is in the aur
       curl -Lfs "$PKGURL/packages/$package/?comments=all" > "$tmpdir/$package.html"
-      cstatus=$?; curlyq "$cstatus"
+      cstatus=$?; curlyq "$cstatus" "$package"
       [[ -s "$tmpdir/$package.html" ]] || err "${COLOR7}error:${ENDCOLOR} package '$package' was not found"
 
       separator="======================================"


### PR DESCRIPTION
`curlyq`'s messages are currently confusing to useless during full upgrades (-Syu), e.g.:

```
:: Synchronizing aur database...
notice: curl exited with code 51            13  34 [---------------------c o  o  o  o  o  o  o  o  o  o  o  o  o] 38%
notice: curl exited with code 51            14  34 [-----------------------c  o  o  o  o  o  o  o  o  o  o  o  o] 41%
manpage: The peer's SSL certificate or SSH MD5 fingerprint was not OK.
manpage: The peer's SSL certificate or SSH MD5 fingerprint was not OK.-------co  o  o  o  o  o  o  o  o  o  o  o] 44%
notice: curl exited with code 51            22  34 [-------------------------------------co  o  o  o  o  o  o  o] 64%
manpage: The peer's SSL certificate or SSH MD5 fingerprint was not OK.
notice: curl exited with code 51            34  34 [-------------------------------------------------------------]100%
manpage: The peer's SSL certificate or SSH MD5 fingerprint was not OK.

:: Starting full aur upgrade...
```

What the error message *means* is that the packages in question don't exist on AUR (any more), but right now you don't even know which packages. With these changes, the output becomes

```
:: Synchronizing aur database...
notice: curl exited with code 51 on connman-notify [--------------C  o  o  o  o  o  o  o  o  o  o  o  o  o  o  o] 26%
manpage: The peer's SSL certificate or SSH MD5 fingerprint was not OK.
notice: curl exited with code 51 on pandoc-bin  34 [---------------------------------c o  o  o  o  o  o  o  o  o] 58%
manpage: The peer's SSL certificate or SSH MD5 fingerprint was not OK.-----------------c  o  o  o  o  o  o  o  o] 61%
notice: curl exited with code 51 on yswrapdmenu 34 [-------------------------------------------------------------]100%
manpage: The peer's SSL certificate or SSH MD5 fingerprint was not OK.
notice: curl exited with code 51 on dmenu-xft
manpage: The peer's SSL certificate or SSH MD5 fingerprint was not OK.

:: Starting full aur upgrade...
```

, which is somewhat more useful. Still doesn't solve the underlying problem (trying to download `https:/plain/PKGBUILD?h=aur` instead of just bailing out), but I've no idea where to fix that one.