### PR TITLE
Fix zsh-completion

### DIFF
--- a/zsh-completion
+++ b/zsh-completion
@@ -446,7 +446,7 @@ _apacman_zsh_comp() {
 	esac
 }
 
-_pacman_comp() {
+_apacman_comp() {
 	case "$service" in
 		apacman)
 			_apacman_zsh_comp "$@"


### PR DESCRIPTION
Fixes auto completion bug:
```
_apacman:460: command not found: _apacman_comp
```