### PR TITLE
Improving split package support.

### DIFF
--- a/apacman
+++ b/apacman
@@ -281,10 +281,11 @@ infoparser() {
 parser() {
   if [ -f "$1" ]; then
     if [[ $nosource == 1 ]]; then
-      unset pkgname pkgver pkgrel arch checkdepends makedepends depends
+      unset pkgname pkgver pkgrel arch checkdepends makedepends depends epoch
       pkgname=$(grep -o "^pkgname=\S*" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_.\n');
       pkgver=$(grep -o "^pkgver=\S*" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_.\n');
       pkgrel=$(grep -o "^pkgrel=\S*" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_.\n');
+      epoch=$(grep -o "^epoch=\S*" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_.\n');
       _arch=$(grep "^arch=" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_. \n');
       _checkdepends=$(grep "^checkdepends=" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_. \n');
       _makedepends=$(grep "^makedepends=" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_. \n');
@@ -1096,7 +1097,8 @@ aurmakepkg() {
   # Reparse PKGBUILD, possibly modified during build
   parser PKGBUILD
   # Save packages
-  pkgtar=$(ls $1-$pkgver*$PKGEXT 2>/dev/null | tail -n 1)
+  [ ${epoch} ] && epoch=${epoch}:
+  pkgtar=$(ls $1-${epoch}${pkgver}*${PKGEXT} 2>/dev/null | tail -n 1)
   if [[ $pkgtar ]]; then
     [ -d $savedir ] || mkdir -p $savedir 2>/dev/null || runasroot mkdir -p $savedir
     echo -e "${COLOR5}  -> ${COLOR1}Saving package:${ENDCOLOR} ${pkgtar}"

--- a/apacman
+++ b/apacman
@@ -1093,8 +1093,10 @@ aurmakepkg() {
     buildstatus 0
   fi
 
+  # Reparse PKGBUILD, possibly modified during build
+  parser PKGBUILD
   # Save packages
-  pkgtar=$(ls $1-*$PKGEXT 2>/dev/null | tail -n 1)
+  pkgtar=$(ls $1-$pkgver*$PKGEXT 2>/dev/null | tail -n 1)
   if [[ $pkgtar ]]; then
     [ -d $savedir ] || mkdir -p $savedir 2>/dev/null || runasroot mkdir -p $savedir
     echo -e "${COLOR5}  -> ${COLOR1}Saving package:${ENDCOLOR} ${pkgtar}"


### PR DESCRIPTION
When installing `spl-linux` the old `ls` command would always match `spl-linux-headers-0.7.1_4.12.4_1-1-x86_64.pkg.tar.xz` instead of `spl-linux-0.7.1_4.12.4_1-1-x86_64.pkg.tar.xz`.