### PR TITLE
Collection of bug fixes - Change regex to basic

### DIFF
--- a/apacman
+++ b/apacman
@@ -1766,7 +1766,7 @@ if [[ $option = search || $option = searchinstall ]]; then
     wait
     cp "$tmpdir/${packageargs[0]}.search" "$tmpdir/search.results"
     for ((i=1 ; i<${#packageargs[@]} ; i++)); do
-      [[ "$(echo ${packageargs[$i]} | tr -dc $valid_pkgname)"
+      regexmatch="$(echo ${packageargs[$i]} | tr -dc $valid_pkgname)"
       if [[ ${packageargs[$i]} != $regexmatch ]]; then
         echo -e "${COLOR6}notice:${ENDCOLOR} enabling regex mode (${packageargs[$i]})"
         grep --color=always -G "${packageargs[$i]}" "$tmpdir/search.results" > "$tmpdir/search.results-2"

--- a/apacman
+++ b/apacman
@@ -131,17 +131,17 @@ ctrlc() {
 }
 
 err() {
-  echo -e "$1"
+  echo -e "$1" >&2
   [[ "$warn" == 1 ]] || exit 3
 }
 
 dne() {
-  echo -e "$1"
+  echo -e "$1" >&2
   [[ "$warn" == 1 ]] || exit 5
 }
 
 invalid() {
-  echo -e "${COLOR7}error:${ENDCOLOR} invalid option \`$1'"
+  echo -e "${COLOR7}error:${ENDCOLOR} invalid option \`$1'" >&2
   [[ $nofail ]] && exit 2
 }
 
@@ -408,11 +408,11 @@ pickone() {
   choices=( $(echo $@) )
 
   for v in ${choices[@]}; do
-    echo "${n}) $v";
+    echo "${n}) $v" >/dev/tty
     n=$((n+1))
   done
-  echo
-  echo -n "Enter a selection (default=1): "
+  echo >/dev/tty
+  echo -n "Enter a selection (default=1): " >/dev/tty
   read -r
 
   # Parse answer

--- a/apacman
+++ b/apacman
@@ -113,6 +113,16 @@ if [[ -t 1 && ! $COLOR = "NO" ]]; then
   S='\\'
 fi
 _WIDTH="$(stty size | cut -d ' ' -f 2)"
+_WIDTH="${_WIDTH:-80}"
+
+#Valid Chars
+#https://wiki.archlinux.org/index.php/PKGBUILD#Package_name
+valid_pkgname='a-z0-9-_.+@\n'
+valid_pkgver='a-z0-9.\n'
+valid_pkgrel='a-z0-9.\n'
+valid_epoch='0-9\n'
+valid_arch='a-z0-9_\n'
+
 
 trap ctrlc INT
 ctrlc() {
@@ -282,14 +292,14 @@ parser() {
   if [ -f "$1" ]; then
     if [[ $nosource == 1 ]]; then
       unset pkgname pkgver pkgrel arch checkdepends makedepends depends epoch
-      pkgname=$(grep -o "^pkgname=\S*" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_.\n');
-      pkgver=$(grep -o "^pkgver=\S*" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_.\n');
-      pkgrel=$(grep -o "^pkgrel=\S*" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_.\n');
-      epoch=$(grep -o "^epoch=\S*" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_.\n');
-      _arch=$(grep "^arch=" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_. \n');
-      _checkdepends=$(grep "^checkdepends=" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_. \n');
-      _makedepends=$(grep "^makedepends=" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_. \n');
-      _depends=$(grep "^depends=" "$1" | awk -F = '{print $2}' | tr -dc 'a-z0-9-_. \n');
+      pkgname=$(grep -o "^pkgname=\S*" "$1" | awk -F = '{print $2}' | tr -dc $valid_pkgname);
+      pkgver=$(grep -o "^pkgver=\S*" "$1" | awk -F = '{print $2}' | tr -dc $valid_pkgver);
+      pkgrel=$(grep -o "^pkgrel=\S*" "$1" | awk -F = '{print $2}' | tr -dc $valid_pkgrel);
+      epoch=$(grep -o "^epoch=\S*" "$1" | awk -F = '{print $2}' | tr -dc $valid_epoch);
+      _arch=$(grep "^arch=" "$1" | awk -F = '{print $2}' | tr -dc $valid_arch);
+      _checkdepends=$(grep "^checkdepends=" "$1" | awk -F = '{print $2}' | tr -dc $valid_pkgname);
+      _makedepends=$(grep "^makedepends=" "$1" | awk -F = '{print $2}' | tr -dc $valid_pkgname);
+      _depends=$(grep "^depends=" "$1" | awk -F = '{print $2}' | tr -dc $valid_pkgname);
 
       for _machine in $_arch; do arch+=("$_machine"); done
       for _pkg in $_checkdepends; do depends+=("$_pkg"); done
@@ -314,7 +324,7 @@ parser() {
 
 # grep PKGBUILD arrays ($1 is array var)
 pkgbuildgrep() {
-  grep "^${1}=" PKGBUILD 2>/dev/null | awk -F = '{print $2}' | tr -dc 'a-z0-9-_. \n';
+  grep "^${1}=" PKGBUILD 2>/dev/null | awk -F = '{print $2}' | tr -dc $valid_pkgname;
 }
 
 # Source apacman.conf file
@@ -358,7 +368,7 @@ existsinaur() {
   chosenpkg=$(echo "$1" | sed 's/\~$//' | awk -F "==" '{print $1}')
   val="${!2}"
 
-  regexmatch="$(echo $val | tr -dc '0-9a-z-.\n')"
+  regexmatch="$(echo $val | tr -dc $valid_pkgname)"
   if [[ $val != $regexmatch ]]; then
      matches=$(aurpkglist "$val")
      selectprovider "$val" $matches
@@ -573,6 +583,7 @@ aurbar() {
   endbar="]"
   perc="$(($1*100/$2))"
   width="$(stty size)"
+  width="${width:-80}"
   width="${width##* }"
   infolen="$(($width*6/10))"
   [ $infolen -lt 50 ] && infolen=50
@@ -1537,7 +1548,7 @@ fi
 # Install (-S) handling
 if [[ $option = install ]]; then
   for pkg in ${packageargs[@]}; do
-    regexmatch="$(echo $pkg | tr -dc '0-9a-z-.\n')"
+    regexmatch="$(echo $pkg | tr -dc $valid_pkgname)"
     if [[ "$pkg" =~ ^/ ]]; then
       err "${COLOR7}error:${ENDCOLOR} invalid package name $pkg"
     elif [[ $regex = 1 ]]; then
@@ -1755,10 +1766,10 @@ if [[ $option = search || $option = searchinstall ]]; then
     wait
     cp "$tmpdir/${packageargs[0]}.search" "$tmpdir/search.results"
     for ((i=1 ; i<${#packageargs[@]} ; i++)); do
-      regexmatch="$(echo ${packageargs[$i]} | tr -dc '0-9A-Za-z-.\n')"
+      [[ "$(echo ${packageargs[$i]} | tr -dc $valid_pkgname)"
       if [[ ${packageargs[$i]} != $regexmatch ]]; then
         echo -e "${COLOR6}notice:${ENDCOLOR} enabling regex mode (${packageargs[$i]})"
-        grep --color=always -E "${packageargs[$i]}" "$tmpdir/search.results" > "$tmpdir/search.results-2"
+        grep --color=always -G "${packageargs[$i]}" "$tmpdir/search.results" > "$tmpdir/search.results-2"
       else
         grep -xFf "$tmpdir/search.results" "$tmpdir/${packageargs[$i]}.search" > "$tmpdir/search.results-2"
       fi


### PR DESCRIPTION
Addresses the following:

Resolves #63 
 * Instead of using Extended Regex (which interferes with some symbols), just use Basic Regex
 * Wildcards are supported as `.*` (example: `apacman -S apacm.*`)

Resolves #79 
 * Add support for `+` and `@` symbols in packages
 * No need to disable regex mode as it will only be enabled if there are unsupported symbols detected

Resolves #80 
 * `echo` to `/dev/tty` to ensure it is visible

Resolves #86 
 * Ensures width variables are defined before using them in math

Additionally, this fixes some of the tests in `tests.bats` (including a `proot` crash workaround) and skips testing non-existant "broken" package.

I also made sure to run the tests.bats file against my changes before submitting the pull request:

```
$ bats tests.bats
 ✓ test command is found
 ✓ invoking without arguments prints usage
 ✓ invoke with nonexistent parameter returns 1
 ✓ invoking with '--help' parameter prints usage
 ✓ invoke with '--version' parameter prints ascii art
 ✓ invoke with '--verbose' parameter without package argument
 ✓ test internet connectivity
 ✓ interactive search install package
 ✓ interactive search install nonexistant package
 ✓ invoke with '-S' parameter installs package from AUR
 - invoke with '-S' parameter fails to build broken package from AUR (skipped)
 ✓ invoke with '-S' parameter installs cached AUR package
 ✓ invoke with '-S' parameter installs non-AUR package
 ✓ invoke with '-S' parameter fails to install nonexistant package
 ✓ prepare proot environment
 ✓ invoke with '-G' parameter download AUR package source
 ✓ invoke with '-G' parameter download old AUR package source
 1) 0.7-2 with '-G' parameter choose download old AUR package source                                     18/22
2) 0.7-1

 ✓ invoke with '-G' parameter choose download old AUR package source
 - invoke with '-S' parameter install package group (skipped)
 1) noto-fonts '-S' parameter install virtual package                                                    20/22
2) noto-fonts-extra
3) ttf-bitstream-vera
4) ttf-croscore
5) ttf-dejavu
6) ttf-freefont
7) ttf-linux-libertine
8) ttf-droid
9) ttf-liberation
10) ttf-ubuntu-font-family

 ✓ invoke with '-S' parameter install virtual package
 ✓ clean proot environment
 ✓ invoke with '-L' parameter lists installed packages by size

22 tests, 0 failures, 2 skipped
```

Let me know if there's anything you want to discuss